### PR TITLE
FeatureRepMix

### DIFF
--- a/examples/feature_rep_mix_example.py
+++ b/examples/feature_rep_mix_example.py
@@ -1,0 +1,40 @@
+'''
+============================
+Simple FeatureRepMix Example
+============================
+
+This example demonstrates how to use the FeatureRepMix on segmented data.
+'''
+
+# Author: Matthias Gazzari
+# License: BSD
+
+from seglearn.transform import SegmentXY, FeatureRep, FeatureRepMix
+from seglearn.feature_functions import minimum, maximum
+from seglearn.base import TS_Data
+
+import numpy as np
+import pandas as pd
+
+X = [np.array([[0,1,2,3], [4,5,6,7], [8,9,10,11]])]
+y = [np.array([True, False, False])]
+
+segment = SegmentXY(width=3, overlap=1)
+X, y, _ = segment.fit_transform(X, y)
+
+print('After segmentation:')
+print(X, X.shape)
+print(y, y.shape)
+
+union = FeatureRepMix([
+    ('a', FeatureRep(features={'min': minimum}), 0),
+    ('b', FeatureRep(features={'min': minimum}), 1),
+    ('c', FeatureRep(features={'min': minimum}), [2,3]),
+    ('d', FeatureRep(features={'max': maximum}), slice(0,2)),
+    ('e', FeatureRep(features={'max': maximum}), [False, False, True, True]),
+])
+
+X = union.fit_transform(X, y)
+print('After column-wise feature extraction:')
+df = pd.DataFrame(data=X, columns=union.f_labels)
+print(df)

--- a/seglearn/__init__.py
+++ b/seglearn/__init__.py
@@ -12,8 +12,8 @@ from .split import TemporalKFold, temporal_split
 from .transform import SegmentX, SegmentXY, SegmentXYForecast, PadTrunc, Interp, FeatureRep
 from .util import check_ts_data, check_ts_data_with_ts_target, ts_stats, get_ts_data_parts
 
-__all__ = ['TS_Data', 'FeatureRep', 'PadTrunc', 'Interp', 'Pype', 'SegmentX', 'SegmentXY',
-           'SegmentXYForecast', 'TemporalKFold', 'temporal_split', 'check_ts_data',
+__all__ = ['TS_Data', 'FeatureRep', 'FeatureRepMix', 'PadTrunc', 'Interp', 'Pype', 'SegmentX',
+           'SegmentXY', 'SegmentXYForecast', 'TemporalKFold', 'temporal_split', 'check_ts_data',
            'check_ts_data_with_ts_target', 'ts_stats', 'get_ts_data_parts', 'all_features',
            'base_features', 'load_watch', 'TargetRunLengthEncoder', '__version__']
 

--- a/seglearn/tests/test_transform.py
+++ b/seglearn/tests/test_transform.py
@@ -401,5 +401,49 @@ def test_interp():
     assert np.all(np.isin(yc, np.arange(6)))
 
 
+def test_feature_rep_mix():
+    union = transform.FeatureRepMix([
+        ('a', transform.FeatureRep(features={'mean': mean}), 0),
+        ('b', transform.FeatureRep(features={'mean': mean}), 1),
+        ('c', transform.FeatureRep(features={'mean': mean}), [2,3]),
+        ('d', transform.FeatureRep(features={'mean': mean}), slice(0,2)),
+        ('e', transform.FeatureRep(features={'mean': mean}), [False, False, True, True]),
+    ])
 
+    # multivariate ts
+    X = np.random.rand(100, 10, 4)
+    y = np.ones(100)
+    union.fit(X, y)
+    Xt = union.transform(X)
+    assert Xt.shape[0] == len(X)
+    assert len(union.f_labels) == Xt.shape[1]
 
+    # ts with multivariate contextual data
+    X = TS_Data(np.random.rand(100, 10, 4), np.random.rand(100, 3))
+    y = np.ones(100)
+    union.fit(X, y)
+    Xt = union.transform(X)
+    assert Xt.shape[0] == len(X)
+    assert len(union.f_labels) == Xt.shape[1]
+
+    # ts with univariate contextual data
+    X = TS_Data(np.random.rand(100, 10, 4), np.random.rand(100))
+    y = np.ones(100)
+    union.fit(X, y)
+    Xt = union.transform(X)
+    assert Xt.shape[0] == len(X)
+    assert len(union.f_labels) == Xt.shape[1]
+
+    # univariate ts
+    uni_union = transform.FeatureRepMix([
+        ('a', transform.FeatureRep(features={'mean': mean}), 0),
+        ('b', transform.FeatureRep(features={'mean': mean}), [0]),
+        ('c', transform.FeatureRep(features={'mean': mean}), slice(0,1)),
+        ('d', transform.FeatureRep(features={'mean': mean}), [True]),
+    ])
+    X = np.random.rand(100, 10)
+    y = np.ones(100)
+    uni_union.fit(X, y)
+    Xt = uni_union.transform(X)
+    assert Xt.shape[0] == len(X)
+    assert len(uni_union.f_labels) == Xt.shape[1]

--- a/seglearn/transform.py
+++ b/seglearn/transform.py
@@ -15,7 +15,8 @@ from .feature_functions import base_features
 from .base import TS_Data
 from .util import get_ts_data_parts, check_ts_data
 
-__all__ = ['SegmentX', 'SegmentXY', 'SegmentXYForecast', 'PadTrunc', 'Interp', 'FeatureRep']
+__all__ = ['SegmentX', 'SegmentXY', 'SegmentXYForecast', 'PadTrunc', 'Interp', 'FeatureRep',
+           'FeatureRepMix']
 
 
 class XyTransformerMixin(object):

--- a/seglearn/transform.py
+++ b/seglearn/transform.py
@@ -1040,7 +1040,7 @@ class FeatureRepMix(_BaseComposition, TransformerMixin):
             return list(range(start, stop, step))
         elif isinstance(cols, list) and cols:
             if isinstance(cols[0], bool):
-                return np.flatnonzero(cols)
+                return np.flatnonzero(np.asarray(cols))
             elif isinstance(cols[0], int):
                 return cols
         else:

--- a/seglearn/transform.py
+++ b/seglearn/transform.py
@@ -8,6 +8,7 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_random_state, check_array
 from sklearn.exceptions import NotFittedError
+from sklearn.utils.metaestimators import _BaseComposition
 from scipy.interpolate import interp1d
 
 from .feature_functions import base_features
@@ -915,3 +916,218 @@ class FeatureRep(BaseEstimator, TransformerMixin):
             f_labels += s_labels
 
         return f_labels
+
+
+class FeatureRepMix(_BaseComposition, TransformerMixin):
+    '''
+    A transformer for calculating a feature representation from segmented time series data.
+
+    This transformer calculates features from the segmented time series', by applying the supplied
+    list of FeatureRep transformers on the specified columns of data. Non-specified columns are
+    dropped.
+
+    The segmented time series data is expected to enter this transform in the form of
+    num_samples x segment_size x num_features and to leave this transform in the form of
+    num_samples x num_features. The term columns refers to the last dimension of both
+    representations.
+
+    Note: This code is partially taken (_validate and _transformers functions with docstring) from
+          the scikit-learn ColumnTransformer made available under the 3-Clause BSD license.
+
+    Parameters
+    ----------
+    transformers : list of (name, transformer, columns) to be applied on the segmented time series
+
+        name : unique string which is used to prefix the f_labels of the FeatureRep below
+        transformer : FeatureRep transform to be applied on the columns specified below
+        columns : integer, slice or boolean mask to specify the columns to be transformed
+
+    Attributes
+    ----------
+    f_labels : list of string feature labels (in order) corresponding to the computed features
+
+    Examples
+    --------
+
+    >>> from seglearn.transform import FeatureRepMix, FeatureRep, SegmentX
+    >>> from seglearn.pipe import Pype
+    >>> from seglearn.feature_functions import mean, var, std, skew
+    >>> from seglearn.datasets import load_watch
+    >>> from sklearn.ensemble import RandomForestClassifier
+    >>> data = load_watch()
+    >>> X = data['X']
+    >>> y = data['y']
+    >>> mask = [False, False, False, True, True, True]
+    >>> clf = Pype([('seg', SegmentX()),
+    >>>             ('union', FeatureRepMix([
+    >>>                 ('ftr_a', FeatureRep(features={'mean': mean}), 0),
+    >>>                 ('ftr_b', FeatureRep(features={'var': var}), [0,1,2]),
+    >>>                 ('ftr_c', FeatureRep(features={'std': std}), slice(3,7)),
+    >>>                 ('ftr_d', FeatureRep(features={'skew': skew}), mask),
+    >>>             ])),
+    >>>             ('rf',RandomForestClassifier())])
+    >>> clf.fit(X, y)
+    >>> print(clf.score(X, y))
+
+    '''
+
+    def __init__(self, transformers):
+        self.transformers = transformers
+        self.f_labels = None
+
+    @property
+    def _transformers(self):
+        '''
+        Internal list of transformers only containing the name and transformers, dropping the
+        columns. This is for the implementation of get_params via BaseComposition._get_params which
+        expects lists of tuples of len 2.
+        '''
+        return [(name, trans) for name, trans, _ in self.transformers]
+
+    @_transformers.setter
+    def _transformers(self, value):
+        self.transformers = [
+            (name, trans, col) for ((name, trans), (_, _, col))
+            in zip(value, self.transformers)]
+
+    def get_params(self, deep=True):
+        '''
+        Get parameters for this transformer.
+
+        Parameters
+        ----------
+        deep : boolean, optional
+            If True, will return the parameters for this transformer and contained transformers.
+
+        Returns
+        -------
+        params : mapping of string to any parameter names mapped to their values.
+        '''
+        return self._get_params('_transformers', deep=deep)
+
+    def set_params(self, **kwargs):
+        '''
+        Set the parameters of this transformer.
+
+        Valid parameter keys can be listed with ``get_params()``.
+
+        Returns
+        -------
+        self
+        '''
+        self._set_params('_transformers', **kwargs)
+        return self
+
+    @staticmethod
+    def _select(Xt, cols):
+        '''
+        Select slices of the last dimension from time series data of the form
+        num_samples x segment_size x num_features.
+        '''
+        return np.atleast_3d(Xt)[:, :, cols]
+
+    @staticmethod
+    def _retrieve_indices(cols):
+        '''
+        Retrieve a list of indices corresponding to the provided column specification.
+        '''
+        if isinstance(cols, int):
+            return [cols]
+        elif isinstance(cols, slice):
+            start = cols.start if cols.start else 0
+            stop = cols.stop
+            step = cols.step if cols.step else 1
+            return list(range(start, stop, step))
+        elif isinstance(cols, list) and cols:
+            if isinstance(cols[0], bool):
+                return np.flatnonzero(cols)
+            elif isinstance(cols[0], int):
+                return cols
+        else:
+            raise TypeError('No valid column specifier. Only a scalar, list or slice of all'
+                            'integers or a boolean mask are allowed.')
+
+    def fit(self, X, y=None):
+        '''
+        Fit the transform
+
+        Parameters
+        ----------
+        X : array-like, shape [n_series, ...]
+            Segmented time series data and (optionally) contextual data
+        y : None
+            There is no need of a target in a transformer, yet the pipeline API requires this
+            parameter.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        '''
+        Xt, Xc = get_ts_data_parts(X)
+        self.f_labels = []
+
+        # calculated features (prefix with the FeatureRep name and correct the index)
+        for name, trans, cols in self.transformers:
+            indices = self._retrieve_indices(cols)
+            trans.fit(self._select(Xt, cols))
+            for label, index in zip(trans.f_labels, indices):
+                self.f_labels.append(name + '_' + label.rsplit('_', 1)[0] + '_' + str(index))
+
+        # contextual features
+        if Xc is not None:
+            Ns = len(np.atleast_1d(Xc[0]))
+            self.f_labels += ['context_' + str(i) for i in range(Ns)]
+
+        return self
+
+    def _validate(self):
+        '''
+        Internal function to validate the transformer before applying all internal transformers.
+        '''
+        if self.f_labels is None:
+            raise NotFittedError('FeatureRepMix')
+
+        if not self.transformers:
+            return
+
+        names, transformers, _ = zip(*self.transformers)
+
+        # validate names
+        self._validate_names(names)
+
+        # validate transformers
+        for trans in transformers:
+            if not isinstance(trans, FeatureRep):
+                raise TypeError("All transformers must be an instance of FeatureRep."
+                                " '%s' (type %s) doesn't." % (trans, type(trans)))
+
+    def transform(self, X):
+        '''
+        Transform the segmented time series data into feature data.
+        If contextual data is included in X, it is returned with the feature data.
+
+        Parameters
+        ----------
+        X : array-like, shape [n_series, ...]
+            Segmented time series data and (optionally) contextual data
+
+        Returns
+        -------
+        X_new : array shape [n_series, ...]
+            Feature representation of segmented time series data and contextual data
+
+        '''
+        self._validate()
+
+        Xt, Xc = get_ts_data_parts(X)
+        check_array(Xt, dtype='numeric', ensure_2d=False, allow_nd=True)
+
+        # calculated features
+        fts = np.column_stack([trans.transform(self._select(Xt, cols))
+                               for _, trans, cols in self.transformers])
+        # contextual features
+        if Xc is not None:
+            fts = np.column_stack([fts, Xc])
+
+        return fts


### PR DESCRIPTION
Hi David,

I implemented a FeatureRepMix as discussed in #9 supporting contextual data. Instead of deriving from ColumnTransformer, I derived the class from _BaseComposition in order to have a less hacky solution (no need to disable unwanted features as in the previous solution) and combined it with large parts of the FeatureRep implementation.
The only missing feature is the parallel execution of all FeatureRep transformers which could easily be added in the future.

Likewise, I changed the example and added tests in close resemblance to the FeatureRep tests. I hope that you are fine with that, as I am currently a bit short of time for more sophisticated tests.

Cheers,
Matthias