### PR TITLE
Add FunctionXYTransformer

### DIFF
--- a/examples/plot_function_xy_transformer.py
+++ b/examples/plot_function_xy_transformer.py
@@ -1,0 +1,48 @@
+'''
+====================================
+Simple FunctionXYTransformer Example
+====================================
+
+This example demonstrates how to execute arbitrary functions on time series data using the
+FunctionXYTransformer.
+
+'''
+
+# Author: Matthias Gazzari
+# License: BSD
+
+from seglearn.transform import FunctionXYTransformer, SegmentXY
+from seglearn.base import TS_Data
+
+import numpy as np
+
+def choose_cols(Xt, yt, cols):
+	return [time_series[:, cols] for time_series in Xt], yt
+
+def invert_y(Xt, yt):
+	return Xt, np.logical_not(yt)
+
+# Multivariate time series with 4 samples of 3 variables
+X = [
+	np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]]),
+	np.array([[30, 40, 50], [60, 70, 80], [90, 100, 110]]),
+]
+# Time series target
+y = [
+	np.array([True, False, False, True]),
+	np.array([False, True, False]),
+]
+
+trans = FunctionXYTransformer(choose_cols, func_kwargs={"cols":[0,1]})
+X, y, _ = trans.fit_transform(X, y)
+
+segment = SegmentXY(width=3, overlap=1)
+X, y, _ = segment.fit_transform(X, y)
+
+print("X:", X)
+print("y: ", y)
+
+trans = FunctionXYTransformer(invert_y)
+X, y, _ = trans.fit_transform(X, y)
+
+print("~y: ", y)

--- a/seglearn/__init__.py
+++ b/seglearn/__init__.py
@@ -15,6 +15,7 @@ from .util import check_ts_data, check_ts_data_with_ts_target, ts_stats, get_ts_
 __all__ = ['TS_Data', 'FeatureRep', 'FeatureRepMix', 'PadTrunc', 'Interp', 'Pype', 'SegmentX',
            'SegmentXY', 'SegmentXYForecast', 'TemporalKFold', 'temporal_split', 'check_ts_data',
            'check_ts_data_with_ts_target', 'ts_stats', 'get_ts_data_parts', 'all_features',
-           'base_features', 'load_watch', 'TargetRunLengthEncoder', '__version__']
+           'base_features', 'load_watch', 'TargetRunLengthEncoder', 'FunctionXYTransformer',
+           '__version__']
 
 __author__ = 'David Burns david.mo.burns@gmail.com'

--- a/seglearn/tests/test_transform.py
+++ b/seglearn/tests/test_transform.py
@@ -1,6 +1,8 @@
 # Author: David Burns
 # License: BSD
 
+import pytest
+
 import numpy as np
 
 import seglearn.transform as transform
@@ -520,3 +522,22 @@ def test_function_xy_transform():
     assert np.array_equal(Xtt, np.ones(Xt.shape) * constant)
     assert Xtc is Xc
     assert np.array_equal(ytrans, np.ones(y.shape) * constant)
+
+    # test resampling
+    def resample(Xt, yt):
+        return Xt.reshape(1, -1), yt.reshape(1, -1)
+
+    illegal_resampler = transform.FunctionXYTransformer(resample)
+    permitted_resampler = transform.FunctionXYTransformer(resample, disable_resample=False)
+
+    X = np.random.rand(100, 10)
+    y = np.ones(100)
+
+    illegal_resampler.fit(X, y)
+    with pytest.raises(ValueError):
+        Xtrans, ytrans, _ = illegal_resampler.transform(X, y)
+
+    permitted_resampler.fit(X, y)
+    Xtrans, ytrans, _ = permitted_resampler.transform(X, y)
+    assert len(Xtrans) == 1
+    assert len(ytrans) == 1

--- a/seglearn/tests/test_transform.py
+++ b/seglearn/tests/test_transform.py
@@ -447,3 +447,76 @@ def test_feature_rep_mix():
     Xt = uni_union.transform(X)
     assert Xt.shape[0] == len(X)
     assert len(uni_union.f_labels) == Xt.shape[1]
+
+
+def test_function_xy_transform():
+    constant = 10
+    identity = transform.FunctionXYTransformer()
+    def replace(Xt, yt, value):
+        return np.ones(Xt.shape) * value, np.ones(yt.shape) * value
+
+    custom = transform.FunctionXYTransformer(replace, func_kwargs={"value": constant})
+
+    # univariate ts
+    X = np.random.rand(100, 10)
+    y = np.ones(100)
+
+    identity.fit(X, y)
+    Xtrans, ytrans, _ = identity.transform(X, y)
+    assert Xtrans is X
+    assert ytrans is y
+
+    custom.fit(X, y)
+    Xtrans, ytrans, _ = custom.transform(X, y)
+    assert np.array_equal(Xtrans, np.ones(X.shape) * constant)
+    assert np.array_equal(ytrans, np.ones(y.shape) * constant)
+
+    # multivariate ts
+    X = np.random.rand(100, 10, 4)
+    y = np.ones(100)
+
+    identity.fit(X, y)
+    Xtrans, ytrans, _ = identity.transform(X, y)
+    assert Xtrans is X
+    assert ytrans is y
+
+    custom.fit(X, y)
+    Xtrans, ytrans, _ = custom.transform(X, y)
+    assert np.array_equal(Xtrans, np.ones(X.shape) * constant)
+    assert np.array_equal(ytrans, np.ones(y.shape) * constant)
+
+    # ts with univariate contextual data
+    Xt = np.random.rand(100, 10, 4)
+    Xc = np.random.rand(100)
+    X = TS_Data(Xt, Xc)
+    y = np.ones(100)
+
+    identity.fit(X, y)
+    Xtrans, ytrans, _ = identity.transform(X, y)
+    assert Xtrans == X
+    assert ytrans is y
+    
+    custom.fit(X, y)
+    Xtrans, ytrans, _ = custom.transform(X, y)
+    Xtt, Xtc = get_ts_data_parts(Xtrans)
+    assert np.array_equal(Xtt, np.ones(Xt.shape) * constant)
+    assert Xtc is Xc
+    assert np.array_equal(ytrans, np.ones(y.shape) * constant)
+
+    # ts with multivariate contextual data
+    Xt = np.random.rand(100, 10, 4)
+    Xc = np.random.rand(100, 3)
+    X = TS_Data(Xt, Xc)
+    y = np.ones(100)
+
+    identity.fit(X, y)
+    Xtrans, ytrans, _ = identity.transform(X, y)
+    assert Xtrans == X
+    assert ytrans is y
+    
+    custom.fit(X, y)
+    Xtrans, ytrans, _ = custom.transform(X, y)
+    Xtt, Xtc = get_ts_data_parts(Xtrans)
+    assert np.array_equal(Xtt, np.ones(Xt.shape) * constant)
+    assert Xtc is Xc
+    assert np.array_equal(ytrans, np.ones(y.shape) * constant)


### PR DESCRIPTION
Hi David,

I added a generic  transformer which allows one to arbitrarily transform the data (Xt and yt) before or after segmentation using a custom function. Useful examples which come to mind are:
- selecting specific parts of data (e.g. column filter)
- applying filter functions (e.g. bandpass filter EMG data)

I added a safeguard against unintentional sub- or oversampling of the data as this would affect the training data (which is fine) and the test data (which is not fine) . The safeguard can be deactivated to allow for legitimate use cases similar to segmentation or interpolation of the data.

Could you please verify if my reasoning is correct. I would remove the last two commits if it were not.

Cheers,
Matthias