### PR TITLE
transform: Fix numpy 1.16 deprecation warning

### DIFF
--- a/seglearn/transform.py
+++ b/seglearn/transform.py
@@ -539,7 +539,7 @@ def sliding_window(time_series, width, step, order='F'):
     w : array like shape [n_segments, width]
         resampled time series segments
     '''
-    w = np.hstack(time_series[i:1 + i - width or None:step] for i in range(0, width))
+    w = np.hstack([time_series[i:1 + i - width or None:step] for i in range(0, width)])
     result = w.reshape((int(len(w) / width), width), order='F')
     if order == 'F':
         return result


### PR DESCRIPTION
See https://github.com/numpy/numpy/commit/bfe0921f9bdd6b347982a9c998b8b1890040ba5b
for more information about deprecating generators for stack functions.