### PR TITLE
Fix issue59 by changing 'memory' to kwarg in initialization of super in Pype

### DIFF
--- a/seglearn/pipe.py
+++ b/seglearn/pipe.py
@@ -61,7 +61,7 @@ class Pype(Pipeline):
         self.N_test = None
         self.N_fit = None
         self.history = None
-        super(Pype, self).__init__(steps, memory)
+        super(Pype, self).__init__(steps, memory=memory)
 
     def fit(self, X, y=None, **fit_params):
         """


### PR DESCRIPTION
This fixes seglearn Pype's incompatibility with scikit-learn 1.0. Many classes in sklearn 1.0 no longer accept positional arguments. The __init__ function in Pype, which initializes sklearn's Pipeline, has been changed accordingly.